### PR TITLE
feat: add WebDriverIO support and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,9 @@ const { detect } = require('detect-browser-es')
 
 ## Testing
 
-To run the test from root folder run `nr test`, the script will run the original tests from `detect-browser` and the new ones corresponding to the new features, except WebDriverIO detection.
+To run the tests, from root folder run `nr test`, the script will run:
+- the original tests from `detect-browser`
+- Happy DOM and JSDOM tests, except WebDriverIO detection
 
 To test WebDriverIO detection, run one of the following commands (requires Vitest v1.0.0-beta.2, not yet released, tests will not work):
 - `nr wdio-chrome`: Chrome must be installed

--- a/README.md
+++ b/README.md
@@ -39,7 +39,18 @@ const { detect } = require('detect-browser-es')
 ## New Features
 
 - Detect [Happy DOM](https://github.com/capricorn86/happy-dom) and [JSDOM](https://github.com/jsdom/jsdom) when using test environments like [Vitest](https://github.com/vitest-dev/vitest) (check the [test](https://github.com/userquin/detect-browser-es/tree/main/test) folder).
+- Detect [WebDriverIO](https://github.com/webdriverio/webdriverio) when using WebDriverIO tests or test environments like [Vitest](https://github.com/vitest-dev/vitest).
 - ServerInfo via [std-env](https://github.com/unjs/std-env) with [provider](https://github.com/unjs/std-env#provider-detection) and [runtime](https://github.com/unjs/std-env#runtime-detection) detection.
+
+## Testing
+
+To run the test `nr test`, will run the original tests from `detect-browser` and the new ones corresponding to the new features (except `WebDriverIO` detection, requires `WebDriverIO`).
+
+To test the `WebDriverIO` detection, you run one of the following commands:
+- `nr wdio-chrome`: test `WebDriverIO` detection with Chrome (you must have it installed)
+- `nr wdio-edge`: test `WebDriverIO` detection with Edge (you must have it installed)
+- `nr wdio-firefox`: test `WebDriverIO` detection with Firefox (you must have it installed)
+- `nr wdio-safari`: test `WebDriverIO` detection with Safari (you must have it installed) and on MacOS machine.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -44,13 +44,13 @@ const { detect } = require('detect-browser-es')
 
 ## Testing
 
-To run the test `nr test`, will run the original tests from `detect-browser` and the new ones corresponding to the new features (except `WebDriverIO` detection, requires `WebDriverIO`).
+To run the test from root folder run `nr test`, the script will run the original tests from `detect-browser` and the new ones corresponding to the new features, except WebDriverIO detection.
 
-To test the `WebDriverIO` detection, you run one of the following commands:
-- `nr wdio-chrome`: test `WebDriverIO` detection with Chrome (you must have it installed)
-- `nr wdio-edge`: test `WebDriverIO` detection with Edge (you must have it installed)
-- `nr wdio-firefox`: test `WebDriverIO` detection with Firefox (you must have it installed)
-- `nr wdio-safari`: test `WebDriverIO` detection with Safari (you must have it installed) and on MacOS machine.
+To test WebDriverIO detection, run one of the following commands (requires Vitest v1.0.0-beta.2, not yet released, tests will not work):
+- `nr wdio-chrome`: Chrome must be installed
+- `nr wdio-edge`: Edge must be installed
+- `nr wdio-firefox`: Firefox must be installed
+- `nr wdio-safari`: Safari must be installed and only on macOS machine.
 
 ## License
 

--- a/browser-test/browser.test.ts
+++ b/browser-test/browser.test.ts
@@ -4,59 +4,23 @@ import { detect } from '../src'
 
 // TODO: update to vitest 1.beta.2: will not work with 1.beta.1
 
-const provider = env.VITE_PROVIDER
 const browser = env.VITE_BROWSER
 
-describe(`Browser Detection test: ${provider}`, () => {
-  describe.skipIf(platform !== 'win32')('Windows', () => {
-    test('User Agent found', () => {
-      expect(typeof navigator).toBeDefined()
-      expect(typeof navigator?.userAgent).toBeDefined()
-    })
-    test.skipIf(browser !== 'chrome')('Chrome', () => {
-      expect(detect()).toBe('chrome')
-    })
-    test.skipIf(provider === 'webdriverio' || browser !== 'chromium')('Chromium', () => {
-      expect(detect()).toBe('chromium')
-    })
-    test.skipIf(browser !== 'edge')('Edge', () => {
-      expect(detect()).toBe('edge')
-    })
-    test.skipIf(browser !== 'firefox')('FireFox', () => {
-      expect(detect()).toBe('firefox')
-    })
-  })
-  /*
-  describe.skipIf(platform !== 'darwin')('MacOS', () => {
-    test('User Agent found', () => {
-      expect(typeof navigator).toBeDefined()
-      expect(typeof navigator?.userAgent).toBeDefined()
-    })
-    test.skipIf(browser !== 'chrome')('Chrome', () => {
-      expect(detect()).toBe('chrome')
-    })
-    test.skipIf(provider === 'webdriverio' || browser !== 'chromium')('Chromium', () => {
-      expect(detect()).toBe('chromium')
-    })
-    test.skipIf(browser !== 'firefox')('FireFox', () => {
-      expect(detect()).toBe('firefox')
-    })
-  })
+describe('Browser Detection test', () => {
   test('User Agent found', () => {
     expect(typeof navigator).toBeDefined()
     expect(typeof navigator?.userAgent).toBeDefined()
   })
   test.skipIf(browser !== 'chrome')('Chrome', () => {
-    expect(detect()).toBe('chrome')
-  })
-  test.skipIf(provider === 'webdriverio' || browser !== 'chromium')('Chromium', () => {
-    expect(detect()).toBe('chromium')
+    expect(detect()?.name).toBe('chrome')
   })
   test.skipIf(browser !== 'edge')('Edge', () => {
-    expect(detect()).toBe('edge')
+    expect(detect()?.name).toBe('edge')
   })
   test.skipIf(browser !== 'firefox')('FireFox', () => {
-    expect(detect()).toBe('firefox')
+    expect(detect()?.name).toBe('firefox')
   })
-   */
+  test.skipIf(platform !== 'darwin' || browser !== 'safari')('FireFox', () => {
+    expect(detect()?.name).toBe('safari')
+  })
 })

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "wdio-chrome": "BROWSER=chrome vitest --c vitest-browser.config.mts",
     "wdio-edge": "BROWSER=edge vitest --c vitest-browser.config.mts",
     "wdio-firefox": "BROWSER=firefox vitest --c vitest-browser.config.mts",
+    "wdio-safari": "BROWSER=safari vitest --c vitest-browser.config.mts",
     "wdio-test": "pnpm run wdio-chrome && pnpm run wdio-edge && pnpm run wdio-firefox"
   },
   "dependencies": {

--- a/vitest-browser.config.mts
+++ b/vitest-browser.config.mts
@@ -1,12 +1,10 @@
 import process from 'node:process'
 import { defineConfig } from 'vitest/config'
 
-const provider = process.env.PROVIDER ?? 'webdriverio'
-const name = process.env.BROWSER ?? 'chromium'
+const name = process.env.BROWSER ?? 'chrome'
 
 export default defineConfig({
   define: {
-    'process.env.VITE_PROVIDER': JSON.stringify(provider),
     'process.env.VITE_BROWSER': JSON.stringify(name),
   },
   test: {
@@ -14,8 +12,9 @@ export default defineConfig({
     include: ['browser-test/*.test.ts'],
     browser: {
       enabled: true,
-      provider,
+      provider: 'webdriverio',
       name,
+      headless: true,
     },
   },
 })


### PR DESCRIPTION
Playwright test not being added, we're testing in Chrome and Edge.

The Playwright detection on hold, we need to find the way to include it.

closes #5 
closes #7 