### PR TITLE
feat: add user agent client hints detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ const { detect } = require('detect-browser-es')
 - Detect [Happy DOM](https://github.com/capricorn86/happy-dom) and [jsdom](https://github.com/jsdom/jsdom) when using test environments like [Vitest](https://github.com/vitest-dev/vitest) (check the [test](https://github.com/userquin/detect-browser-es/tree/main/test) folder).
 - Detect [WebdriverIO](https://github.com/webdriverio/webdriverio) when using WebdriverIO tests.
 - ServerInfo via [std-env](https://github.com/unjs/std-env) with [provider](https://github.com/unjs/std-env#provider-detection) and [runtime](https://github.com/unjs/std-env#runtime-detection) detection.
+- [User-Agent Client Hints API](https://developer.mozilla.org/en-US/docs/Web/API/User-Agent_Client_Hints_API) client and server detection: via new `async` detect function.
+- Windows 11 browser detection when using the new `async` detection (there is no way to detect Windows 11 using only `user-agent`).
+
+**NOTES**: 
+- the new `asyncDetect` function should be used when you need to detect Windows 11 or detect any User-Agent Client Hints, otherwise you can use the `detect` function.
+- to detect Windows 11, you need to use the `asyncDetect` function providing `platformVersion` in the `options.hints` array.
 
 ## Testing
 

--- a/browser-test/browser.test.ts
+++ b/browser-test/browser.test.ts
@@ -1,5 +1,5 @@
 import { env } from 'std-env'
-import { BrowserInfo, detect, lookupBrowserAgentData } from '../src'
+import { BrowserInfo, asyncDetect, detect } from '../src'
 
 // TODO: update to vitest 1.beta.2: will not work with 1.beta.1
 
@@ -23,22 +23,23 @@ describe('Browser Detection test', () => {
     expect(detect()?.name).toBe('safari')
   })
   test.skipIf(!(browser === 'chrome' || browser === 'edge'))('Detect UserAgentData', async () => {
-    const detectInfo = detect()
+    const detectInfo = await asyncDetect({
+      hints: ['platformVersion'],
+    })
     expect(detectInfo).toBeDefined()
     expect(detectInfo instanceof BrowserInfo).toBeTruthy()
     const browserInfo = detectInfo as BrowserInfo
-    const data = await lookupBrowserAgentData(true)
+    const ua = (detectInfo as BrowserInfo).ua
     // eslint-disable-next-line no-console
-    console.log(JSON.stringify(data ?? {}, null, 2))
+    console.log(JSON.stringify(ua ?? {}, null, 2))
     const os = browserInfo.os
     expect(os).toBeDefined()
+    expect(ua).toBeDefined()
     if (os!.startsWith('Windows')) {
-      expect(data).toBeDefined()
-      expect(data?.platform).toBe('Windows')
-      expect(data?.isWindows10 || data?.isWindows11).toBe(true)
-    }
-    else {
-      expect(data).toBeUndefined()
+      expect(ua?.platform).toBe('Windows')
+      expect(ua?.mobile).toBe(false)
+      expect(ua?.brands?.length ?? 0).toBeGreaterThan(0)
+      expect(detectInfo?.os?.startsWith('Windows ')).toBe(true)
     }
   })
 })

--- a/browser-test/browser.test.ts
+++ b/browser-test/browser.test.ts
@@ -1,5 +1,5 @@
-import { env, platform } from 'std-env'
-import { detect } from '../src'
+import { env } from 'std-env'
+import { BrowserInfo, detect, lookupBrowserAgentData } from '../src'
 
 // TODO: update to vitest 1.beta.2: will not work with 1.beta.1
 
@@ -10,10 +10,6 @@ describe('Browser Detection test', () => {
     expect(typeof navigator).toBeDefined()
     expect(typeof navigator?.userAgent).toBeDefined()
   })
-  // TODO: missing __wdioSpec__ and cookie
-  test.skip('WebdriverIO Detection', () => {
-    expect(detect()?.type).toBe('webdriverio')
-  })
   test.skipIf(browser !== 'chrome')('Chrome', () => {
     expect(detect()?.name).toBe('chrome')
   })
@@ -23,7 +19,26 @@ describe('Browser Detection test', () => {
   test.skipIf(browser !== 'firefox')('FireFox', () => {
     expect(detect()?.name).toBe('firefox')
   })
-  test.skipIf(platform !== 'darwin' || browser !== 'safari')('Safari', () => {
+  test.skipIf(browser !== 'safari')('Safari', () => {
     expect(detect()?.name).toBe('safari')
+  })
+  test.skipIf(!(browser === 'chrome' || browser === 'edge'))('Detect UserAgentData', async () => {
+    const detectInfo = detect()
+    expect(detectInfo).toBeDefined()
+    expect(detectInfo instanceof BrowserInfo).toBeTruthy()
+    const browserInfo = detectInfo as BrowserInfo
+    const data = await lookupBrowserAgentData(true)
+    // eslint-disable-next-line no-console
+    console.log(JSON.stringify(data ?? {}, null, 2))
+    const os = browserInfo.os
+    expect(os).toBeDefined()
+    if (os!.startsWith('Windows')) {
+      expect(data).toBeDefined()
+      expect(data?.platform).toBe('Windows')
+      expect(data?.isWindows10 || data?.isWindows11).toBe(true)
+    }
+    else {
+      expect(data).toBeUndefined()
+    }
   })
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -158,7 +158,7 @@ implements DetectedInfo<'happy-dom', Browser, OperatingSystem | null, string> {
   ) {}
 }
 
-export class WDIOBrowserRunnerInfo
+export class WebdriverIOInfo
 implements DetectedInfo<'webdriverio', Browser, OperatingSystem | null, string> {
   public readonly type = 'webdriverio'
   constructor(
@@ -343,7 +343,7 @@ export function detect(userAgent?: string) {
     if ('__wdioSpec__' in window) {
       const browser = parseUserAgent(navigator.userAgent)
       if (browser instanceof BrowserInfo)
-        return new WDIOBrowserRunnerInfo(browser.name, browser.version, browser.os)
+        return new WebdriverIOInfo(browser.name, browser.version, browser.os)
     }
   }
 
@@ -477,8 +477,8 @@ export async function asyncDetect(options?: {
     isWindows11 = !Number.isNaN(majorPlatformVersion) && majorPlatformVersion >= 13
   }
 
-  if (info instanceof WDIOBrowserRunnerInfo)
-    return new WDIOBrowserRunnerInfo(info.name, info.version, isWindows11 ? 'Windows 11' : info.os, ua)
+  if (info instanceof WebdriverIOInfo)
+    return new WebdriverIOInfo(info.name, info.version, isWindows11 ? 'Windows 11' : info.os, ua)
 
   return new BrowserInfo(info.name, info.version, isWindows11 ? 'Windows 11' : info.os, ua)
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -551,10 +551,10 @@ export function lookupServerUserAgentHints(httpHeaders: Record<string, string | 
         }
       }
       else if (key === 'mobile') {
-        acc[key] = value === '?1'
+        acc[key] = removeDoubleQuotes(value) === '?1'
       }
       else {
-        acc[key] = value
+        acc[key] = removeDoubleQuotes(value)
       }
     }
     return acc

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -49,8 +49,8 @@ describe('Server Detection', () => {
   test('UA Client Hints server detection', () => {
     expect(lookupServerUserAgentHints({
       'Sec-CH-UA': '"Chrome"; v="73", "Chromium"; v="73", "?Not:Your Browser"; v="11"',
-      'Sec-CH-UA-Arch': 'arm',
-      'Sec-CH-UA-Bitness': '64',
+      'Sec-CH-UA-Arch': '"arm"',
+      'Sec-CH-UA-Bitness': '"64"',
       'Sec-CH-UA-Mobile': '?1',
       'Sec-CH-UA-Model': '"Pixel 2 XL"',
       'Sec-CH-UA-Full-Version': '"73.1.2343B.TR"',
@@ -89,8 +89,8 @@ describe('Server Detection', () => {
           },
         ],
         "mobile": true,
-        "model": ""Pixel 2 XL"",
-        "platform": ""Windows"",
+        "model": "Pixel 2 XL",
+        "platform": "Windows",
         "platformVersion": "",
       }
     `)

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -1,5 +1,12 @@
 import { runtime } from 'std-env'
-import { detect, getNodeVersion, getServerVersion } from '../src'
+import { expect } from 'vitest'
+import {
+  detect,
+  getNodeVersion,
+  getServerVersion,
+  lookupServerUserAgentHints,
+  serverResponseHeadersForUserAgentHints,
+} from '../src'
 
 describe('Server Detection', () => {
   test('Server Detection', () => {
@@ -24,5 +31,71 @@ describe('Server Detection', () => {
       expect(serverInfo?.nodeVersion).toBeDefined()
       expect(serverInfo?.nodeMajorVersion).toBeDefined()
     })
+  })
+  test('Accept-CH server response header', () => {
+    expect(serverResponseHeadersForUserAgentHints([
+      'architecture',
+      'bitness',
+      'model',
+      'platformVersion',
+      'fullVersionList',
+    ])).toMatchInlineSnapshot(`
+      {
+        "Accept-CH": "Sec-CH-UA-Arch, Sec-CH-UA-Bitness, Sec-CH-UA-Model, Sec-CH-UA-Platform-Version, Sec-CH-UA-Full-Version-List",
+      }
+    `)
+  })
+  // https://github.com/WICG/ua-client-hints
+  test('UA Client Hints server detection', () => {
+    expect(lookupServerUserAgentHints({
+      'Sec-CH-UA': '"Chrome"; v="73", "Chromium"; v="73", "?Not:Your Browser"; v="11"',
+      'Sec-CH-UA-Arch': 'arm',
+      'Sec-CH-UA-Bitness': '64',
+      'Sec-CH-UA-Mobile': '?1',
+      'Sec-CH-UA-Model': '"Pixel 2 XL"',
+      'Sec-CH-UA-Full-Version': '"73.1.2343B.TR"',
+      'Sec-CH-UA-Platform': '"Windows"',
+      'Sec-CH-UA-Full-Version-List': '"Microsoft Edge"; v="92.0.902.73", "Chromium"; v="92.0.4515.131", "?Not:Your Browser"; v="3.1.2.0"',
+    })).toMatchInlineSnapshot(`
+      {
+        "architecture": "arm",
+        "bitness": "64",
+        "brands": [
+          {
+            "brand": "Chrome",
+            "version": "73",
+          },
+          {
+            "brand": "Chromium",
+            "version": "73",
+          },
+          {
+            "brand": "?Not:Your Browser",
+            "version": "11",
+          },
+        ],
+        "fullVersionList": [
+          {
+            "brand": "Microsoft Edge",
+            "version": "92.0.902.73",
+          },
+          {
+            "brand": "Chromium",
+            "version": "92.0.4515.131",
+          },
+          {
+            "brand": "?Not:Your Browser",
+            "version": "3.1.2.0",
+          },
+        ],
+        "mobile": true,
+        "model": ""Pixel 2 XL"",
+        "platform": ""Windows"",
+        "platformVersion": "",
+      }
+    `)
+    expect(lookupServerUserAgentHints({
+      'Sec-CH-UA-Mobile': '?0',
+    })?.mobile).toBe(false)
   })
 })


### PR DESCRIPTION
Since there is no way to detect Windows 11 using only `user-agent`, this PR adds support for [User-Agent Client Hints API](https://developer.mozilla.org/en-US/docs/Web/API/User-Agent_Client_Hints_API) for browser and server detection.

This PR includes:
- new async detection (browser and server): we can use current detection when User-Agent Client Hints and Windows 11 detection not required
- browser User-Agent Client Hints support
- server User-Agent Client Hints detection (also includes an utility function to create the Accept-CH header)
- Windows 11 detection in browser and server
